### PR TITLE
Resolves issue#1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on: [ push, pull_request ]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-versions: [ '7.3', '7.4', '8.0' ]
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, zip
+          coverage: none
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Check Composer Version
+        run: composer -V
+
+      - name: Check PHP Extensions
+        run: php -m
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies for PHP 7
+        run: composer update --no-progress
+
+      - name: Run test suite
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": ">=7.1.0"
+    "php": ">=7.3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
# Changed log

- Closes #1.
- I also notice that this package uses the `PHPUnit ^9` and it also requires `php-7.3` version at least.
- It's time to drop `php-7.1` and `php-7.2` version support because they're outdated and it can also fix above issue :).
- This GitHub workflow action is available on [my forked repository](https://github.com/open-source-contributions/JustHttpStatusCodes/actions/runs/1681377193).